### PR TITLE
Forgot password

### DIFF
--- a/frontend/src/PasswordReset.jsx
+++ b/frontend/src/PasswordReset.jsx
@@ -1,0 +1,23 @@
+import UserPasswordReset from "./components/UserPasswordReset";
+import "./components/form.css";
+
+function PasswordReset() {
+    const user = {
+        username: "",
+        email: "",
+        password: ""
+    }
+
+    const handleSave = (values) => {
+        console.log({ values });
+    };
+
+    return (
+        <div className="registrationContainer">
+            <h1>Password Reminder</h1>
+            <UserPasswordReset onSave={handleSave} {...{ user }} />
+        </div>
+    );
+}
+
+export default PasswordReset

--- a/frontend/src/PasswordSet.jsx
+++ b/frontend/src/PasswordSet.jsx
@@ -1,0 +1,23 @@
+import UserPasswordSet from "./components/UserPasswordSet";
+import "./components/form.css";
+
+function PasswordSet() {
+    const user = {
+        username: "",
+        email: "",
+        password: ""
+    }
+
+    const handleSave = (values) => {
+        console.log({ values });
+    };
+
+    return (
+        <div className="registrationContainer">
+            <h1>Password Reminder</h1>
+            <UserPasswordSet onSave={handleSave} {...{ user }} />
+        </div>
+    );
+}
+
+export default PasswordSet

--- a/frontend/src/components/UserLogin.jsx
+++ b/frontend/src/components/UserLogin.jsx
@@ -60,6 +60,9 @@ const UserForm = ({ onSave, user = {} }) => {
             return;
         }
     }
+    const passwordReminder = async () => {
+        window.location.href = "/app/passwordreset";
+    }
 
     return (
         <div className="formContainer">
@@ -70,6 +73,14 @@ const UserForm = ({ onSave, user = {} }) => {
             <Field text="password" type="password" default="password" name="password" onChange={handleChange} />
             <div className="errorInformation">{errors.password}</div>
 
+            <Toast.Provider swipeDirection="right">
+                <button
+                    className="formButton"
+                    onClick={passwordReminder}>
+                    Forgot Password
+                        </button>
+                <Toast.Viewport className="ToastViewport" />
+            </Toast.Provider>
 
             <Toast.Provider swipeDirection="right">
                 <button

--- a/frontend/src/components/UserPasswordReset.jsx
+++ b/frontend/src/components/UserPasswordReset.jsx
@@ -1,0 +1,99 @@
+import React, { useState } from "react";
+import validator from "validator";
+import "./form.css";
+// import "./index.css"; not necessary <?>
+
+import * as Toast from '@radix-ui/react-toast';
+import Field from "./field";
+
+const UserPasswordReset = ({ onSave, user = {} }) => {
+    const [userData, setUserData] = useState(user);
+    const [errors, setErrors] = useState({});
+
+    const [open, setOpen] = React.useState(false);
+    const timerRef = React.useRef(0);
+    const [title, setTitle] = useState("Reset succesful");
+    const [text, setText] = useState("Verification sent to provided email");
+
+
+    const { username, email, password } = userData;
+
+    const validateData = () => {
+        let errors = {};
+        if (!validator.isEmail(email)) {
+            errors.email = "A valid email is required!";
+        }
+        return errors;
+    }
+
+    const handleChange = (event) => {
+        const { name, value } = event.target;
+        setUserData((prevData) => ({ ...prevData, [name]: value }));
+    };
+
+
+    const passwordReminder = async () => {
+        const errors = validateData();
+        if (Object.keys(errors).length) {
+            setErrors(errors);
+            return;
+        }
+        setErrors({});
+        let response = await fetch(
+            "http://localhost/api/passwordreset",
+            {
+                method: 'POST',
+                body: JSON.stringify({ email: userData.email }),
+                headers: { 'Content-Type': 'application/json' }
+            }
+        )
+        let resdata = await response.text();
+        console.log(response, resdata);
+        if (response.status !== 201) {
+            setTitle("Reminder error!");
+            setText(`Reason: `);
+        } else {
+            setText(`Password reset instructions sent to your e-mail address`);
+        }
+        setOpen(false);
+        window.clearTimeout(timerRef.current);
+        timerRef.current = window.setTimeout(() => {
+            setOpen(true);
+
+        }, 150);
+        if (response.status === 201) {
+            window.setTimeout(() => {
+                window.location.href = "/app/passwordchange";
+            }, 2000);
+        }
+    }
+
+    return (
+        <div className="formContainer">
+
+            <Field text="e-mail" default="e.g. name@domain.com" name="email" onChange={handleChange} />
+            <div className="errorInformation">{errors.email}</div>
+
+            <Toast.Provider swipeDirection="right">
+                <button
+                    className="formButton"
+                    onClick={passwordReminder}>
+                    Reset Password
+                        </button>
+                <Toast.Root className="ToastRoot" open={open} onOpenChange={setOpen}>
+                    <Toast.Title className="ToastTitle">{title}</Toast.Title>
+                    <Toast.Description asChild><div className="FormInformation">{text}</div>
+                    </Toast.Description>
+                    <Toast.Action className="ToastAction" asChild altText="Goto schedule to undo">
+                        <button className="Button small green">Close</button>
+                    </Toast.Action>
+                </Toast.Root>
+                <Toast.Viewport className="ToastViewport" />
+            </Toast.Provider>
+
+
+        </div>
+    );
+}
+
+export default UserPasswordReset;

--- a/frontend/src/components/UserPasswordSet.jsx
+++ b/frontend/src/components/UserPasswordSet.jsx
@@ -1,0 +1,121 @@
+import React, { useState } from "react";
+import validator from "validator";
+import "./form.css";
+// import "./index.css"; not necessary <?>
+
+import * as Toast from '@radix-ui/react-toast';
+import Field from "./field";
+
+const UserPasswordSet = ({ onSave, user = {} }) => {
+    const [userData, setUserData] = useState(user);
+    const [errors, setErrors] = useState({});
+    const specialCharacters = ['!', '@', '#', '$', '%', '^', '&', '*', '(', ')', '-', '=', '+', '-', '/', '.', ',', '*', '-'];
+
+    const [open, setOpen] = React.useState(false);
+    const timerRef = React.useRef(0);
+    const [title, setTitle] = useState("Reset succesful");
+    const [text, setText] = useState("You should be able to log in using your new password");
+
+    const { username, code, password, password2 } = userData;
+    const specialCharacter = (character) => {
+        for (let i = 0; i < specialCharacters.length; i++) {
+            if (character == specialCharacters[i]) return true
+        }
+        return false
+    };
+    const validateData = () => {
+        let errors = {};
+        if (!username) {
+            errors.name = "Name is required!";
+        }
+        if (!password) {
+            errors.password = "Password is required!";
+        }
+        if (!code) {
+            errors.code = "Verification code from your e-mail is required!"
+        }
+        if (password) {
+            if (password.length < 8) { errors.password = "Password is too short!"; }
+            for (let i = 0; i < password.length; i++) {
+                if (specialCharacter(password[i]) == true) { break };
+                if (i + 1 == password.length) { errors.password = "Password needs to be more complex"; } // Dont ask me bro, it works ok?
+            }
+            if (/[A-Z]/.test(password) == false) {
+                errors.password = "Password needs at least 1 upper case character";
+            }
+
+        }
+        if (password !== password2) { errors.password = "Passwords need to be the same" }
+
+        errors.password2 = errors.password;
+        return errors;
+    }
+
+    const handleChange = (event) => {
+        const { name, value } = event.target;
+        setUserData((prevData) => ({ ...prevData, [name]: value }));
+    };
+
+
+    const passwordReminder = async () => {
+        const errors = validateData();
+        if (Object.keys(errors).length != 0) {
+            setErrors(errors);
+            return;
+        }
+        setErrors({});
+        let response = await fetch(
+            "http://localhost/api/passwordset",
+            {
+                method: 'POST',
+                headers: { 'Authorization': `Basic ${btoa(password + ":" + code)}` }
+            }
+        )
+        let resdata = await response.text();
+        console.log(response, resdata);
+        if (response.status !== 201) {
+            setTitle("Reminder error!");
+            setText(`Reason: ${resdata}`);
+        } else {
+            setText(`Password has been reset!`);
+        }
+        if (response.status === 201) {
+            window.setTimeout(() => {
+                window.location.href = "/app/login";
+            }, 3000);
+        }
+    }
+
+    return (
+        <div className="formContainer">
+
+            <Field text="new password" type="password" default="password" name="password" onChange={handleChange} />
+            <div className="errorInformation">{errors.password}</div>
+            <Field text="new password (repeated)" type="password2" default="password2" name="password2" onChange={handleChange} />
+            <div className="errorInformation">{errors.password2}</div>
+            <Field text="code" type="code" default="code" name="code" onChange={handleChange} />
+            <div className="errorInformation">{errors.code}</div>
+
+            <Toast.Provider swipeDirection="right">
+                <button
+                    className="formButton"
+                    onClick={passwordReminder}>
+                    Change Password
+                        </button>
+                <Toast.Root className="ToastRoot" open={open} onOpenChange={setOpen}>
+                    <Toast.Title className="ToastTitle">{title}</Toast.Title>
+                    <Toast.Description asChild><div className="FormInformation">{text}</div>
+                    </Toast.Description>
+                    <Toast.Action className="ToastAction" asChild altText="Goto schedule to undo">
+                        <button className="Button small green">Close</button>
+                    </Toast.Action>
+                </Toast.Root>
+                <Toast.Viewport className="ToastViewport" />
+            </Toast.Provider>
+
+
+        </div>
+    );
+}
+
+export default UserPasswordSet;

--- a/frontend/src/routes.jsx
+++ b/frontend/src/routes.jsx
@@ -5,6 +5,8 @@ import Login from './Login'
 import Loggedin from './Loggedin'
 import Registrationsuc from './registrationsuc'
 import Tos from './Tos'
+import PasswordReset from './PasswordReset'
+import PasswordSet from './PasswordSet'
 
 
 
@@ -36,6 +38,14 @@ const routes = [
 	{
 		path: "/tos",
 		element: <Tos />
+	},
+	{
+		path: "/passwordreset",
+		element: <PasswordReset />
+	},
+	{
+		path: "/passwordchange",
+		element: <PasswordSet />
 	}
 ]
 


### PR DESCRIPTION
Added forgot password button on login page
After redirection it asks for you e-mail
Then it redirects you to passwordchange site where you need to type new password twice and you code to change your password After successful change it redirects you back to login page Styling tbd - i have no taste in style

Starting the reset process by typing your email sents call to /api/passwordreset where it sends JSON of user e-mail

The second part where user sets their new password uses /api/passwordset and sends in password + code in header

Functionality works frontend wise - when set reseponses to 201/smthg else. Backend left to be done

Frontend wise it resolves issues - #19, #20, #23, #24, #25, #26, #27, #28, #29, #30, #31 